### PR TITLE
Unload bundle after loading all assets

### DIFF
--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -113,32 +113,43 @@ namespace LC_API.BundleAPI
         public static void SaveAsset(string path, bool legacyLoad)
         {
             AssetBundle bundle = AssetBundle.LoadFromFile(path);
-            string[] array = bundle.GetAllAssetNames();
-            //Plugin.Log.LogMessage("Assets: [" + string.Join(", ", array) + "]");
-            foreach (string text in array)
+            try
             {
-                Plugin.Log.LogMessage("Got asset for load: " + text);
-                UnityEngine.Object obj = bundle.LoadAsset(text);
-                if (obj != null)
+                string[] array = bundle.GetAllAssetNames();
+                //Plugin.Log.LogMessage("Assets: [" + string.Join(", ", array) + "]");
+                foreach (string text in array)
                 {
-                    
-                    string text2 = text.ToLower();
-                    if (legacyLoad)
+                    Plugin.Log.LogMessage("Got asset for load: " + text);
+                    UnityEngine.Object obj = bundle.LoadAsset(text);
+                    if (obj != null)
                     {
-                        text2 = text2.ToUpper();
+
+                        string text2 = text.ToLower();
+                        if (legacyLoad)
+                        {
+                            text2 = text2.ToUpper();
+                        }
+                        if (assets.ContainsKey(text2))
+                        {
+                            Plugin.Log.LogError("BundleAPI got duplicate asset!");
+                            return;
+                        }
+                        assets.TryAdd(text2, obj);
+                        Plugin.Log.LogMessage("Loaded asset: " + obj.name);
                     }
-                    if (assets.ContainsKey(text2))
+                    else
                     {
-                        Plugin.Log.LogError("BundleAPI got duplicate asset!");
-                        return;
+                        Plugin.Log.LogWarning("Skipped loading an asset");
                     }
-                    assets.TryAdd(text2, obj);
-                    Plugin.Log.LogMessage("Loaded asset: " + obj.name);
                 }
-                else
-                {
-                    Plugin.Log.LogWarning("Skipped loading an asset");
-                }
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                bundle?.Unload(false);
             }
         }
 

--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -143,10 +143,6 @@ namespace LC_API.BundleAPI
                     }
                 }
             }
-            catch
-            {
-                throw;
-            }
             finally
             {
                 bundle?.Unload(false);


### PR DESCRIPTION
This simply unloads the bundle after all assets are loaded, which keeps the assets loaded but allows other mods to load the same bundle if they desire