### PR TITLE
Easier additions to invalid endings for BundleLoader

### DIFF
--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -72,8 +72,10 @@ namespace LC_API.BundleAPI
                 Plugin.Log.LogWarning("The path BepInEx > Bundles is outdated and should not be used anymore! Bundles will be loaded from BepInEx > plugins from now on");
                 LoadAllAssetsFromDirectory(bundles, legacyLoading);
             }
+
+            string[] invalidEndings = { ".dll", ".json", ".png", ".md", ".old", ".txt", ".exe" };
             bundleDir = Path.Combine(Paths.BepInExRootPath, "plugins");
-            bundles = Directory.GetFiles(bundleDir, "*", SearchOption.AllDirectories).Where(x => !x.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase)).Where(x => !x.EndsWith(".json", StringComparison.CurrentCultureIgnoreCase)).Where(x => !x.EndsWith(".png", StringComparison.CurrentCultureIgnoreCase)).Where(x => !x.EndsWith(".md", StringComparison.CurrentCultureIgnoreCase)).Where(x => !x.EndsWith(".old", StringComparison.CurrentCultureIgnoreCase)).Where(x => !x.EndsWith(".txt", StringComparison.CurrentCultureIgnoreCase)).ToArray();
+            bundles = Directory.GetFiles(bundleDir, "*", SearchOption.AllDirectories).Where(file => !invalidEndings.Any(ending => file.EndsWith(ending, StringComparison.CurrentCultureIgnoreCase))).ToArray();
 
             if (bundles.Length == 0)
             {


### PR DESCRIPTION
Also added .exe to the invalid endings. This was done because my boombox plugin downloads ffmpeg and ytdl which the loader incorrectly identifies as bundles. Though I don't expect exes to be common in plugin folders outside of ffmpeg potentially.