### PR TITLE
Only load actual bundles

### DIFF
--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -77,6 +77,38 @@ namespace LC_API.BundleAPI
             bundleDir = Path.Combine(Paths.BepInExRootPath, "plugins");
             bundles = Directory.GetFiles(bundleDir, "*", SearchOption.AllDirectories).Where(file => !invalidEndings.Any(ending => file.EndsWith(ending, StringComparison.CurrentCultureIgnoreCase))).ToArray();
 
+            byte[] bundleStart = Encoding.ASCII.GetBytes("UnityFS");
+
+            List<string> properBundles = new List<string>();
+
+            foreach (string path in bundles)
+            {
+                byte[] buffer = new byte[bundleStart.Length];
+
+                using (FileStream fs = File.Open(path, FileMode.Open))
+                {
+                    fs.Read(buffer, 0, buffer.Length);
+                }
+
+                bool isProper = true;
+
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    if (buffer[i] != bundleStart[i])
+                    {
+                        isProper = false;
+                        break;
+                    }
+                }
+
+                if (isProper)
+                {
+                    properBundles.Add(path);
+                }
+            }
+
+            bundles = properBundles.ToArray();
+
             if (bundles.Length == 0)
             {
                 Plugin.Log.LogMessage("BundleAPI got no assets to load from plugins folder");

--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -90,18 +90,7 @@ namespace LC_API.BundleAPI
                     fs.Read(buffer, 0, buffer.Length);
                 }
 
-                bool isProper = true;
-
-                for (int i = 0; i < buffer.Length; i++)
-                {
-                    if (buffer[i] != bundleStart[i])
-                    {
-                        isProper = false;
-                        break;
-                    }
-                }
-
-                if (isProper)
+                if (buffer.SequenceEqual(bundleStart))
                 {
                     properBundles.Add(path);
                 }


### PR DESCRIPTION
I kept the invalid endings so that it doesn't search through these files that won't ever be bundles, but I added a check for the first few bytes to ensure they are `UnityFS` as #14 suggests.