### PR TITLE
LethalExpansion compatibility

### DIFF
--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -73,7 +73,7 @@ namespace LC_API.BundleAPI
                 LoadAllAssetsFromDirectory(bundles, legacyLoading);
             }
 
-            string[] invalidEndings = { ".dll", ".json", ".png", ".md", ".old", ".txt", ".exe" };
+            string[] invalidEndings = { ".dll", ".json", ".png", ".md", ".old", ".txt", ".exe", ".lem" };
             bundleDir = Path.Combine(Paths.BepInExRootPath, "plugins");
             bundles = Directory.GetFiles(bundleDir, "*", SearchOption.AllDirectories).Where(file => !invalidEndings.Any(ending => file.EndsWith(ending, StringComparison.CurrentCultureIgnoreCase))).ToArray();
 


### PR DESCRIPTION
My mod LethalExpansion use AssetBundles to load new scraps and moons made with my SDK so having both LethalExpansion and LC_API installed generate errors when LC_API try to load the same bundles as LethalExpansion
On my side i added an extension to the bundles (.lem for Lethal Expansion Module) for the next update, this PR basically adds this extention to the invalid files extensions of it's AssetBundles loader.