### PR TITLE
Improved BundleLoader's error tolerance

### DIFF
--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -85,9 +85,16 @@ namespace LC_API.BundleAPI
             {
                 byte[] buffer = new byte[bundleStart.Length];
 
-                using (FileStream fs = File.Open(path, FileMode.Open))
+                try
                 {
-                    fs.Read(buffer, 0, buffer.Length);
+                    using (FileStream fs = File.Open(path, FileMode.Open))
+                    {
+                        fs.Read(buffer, 0, buffer.Length);
+                    }
+                }
+                catch (IOException ioException)
+                {
+                    Plugin.Log.LogError($"BundleAPI failed to open file \"{path}\": {ioException.Message}\n{ioException.StackTrace}");
                 }
 
                 if (buffer.SequenceEqual(bundleStart))


### PR DESCRIPTION
With this change, BundleLoader now skips files it cannot open instead of completely giving up.

This fixes an incompatibility with [AEIOUCompany](https://github.com/ArbiterBibendi/AEIOUCompany/), which opens some of its included assets exclusively and doesn't ever release them. This meant that it broke all mods that used BundleLoader.