### PR TITLE
(BREAKING) Manual bundle loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+Thunderstore/

--- a/BundleAPI/BundleLoader.cs
+++ b/BundleAPI/BundleLoader.cs
@@ -216,7 +216,7 @@ namespace LC_API.BundleAPI
         /// Loads an entire asset bundle. It is recommended to use this to load asset bundles.
         /// </summary>
         /// <param name="filePath">The file system path of the asset bundle.</param>
-        /// <param name="cache">Whether or not to cache the loaded bundle.</param>
+        /// <param name="cache">Whether or not to cache the loaded bundle. Set to <see langword="false" /> if you cache it yourself.</param>
         /// <returns>A <see cref="Dictionary{TKey, TValue}"/> containing all assets from the bundle mapped to their path in lowercase.</returns>
         public static Dictionary<string, UnityEngine.Object> LoadAssetBundle(string filePath, bool cache = true)
         {

--- a/BundleAPI/LoadedAssetBundle.cs
+++ b/BundleAPI/LoadedAssetBundle.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LC_API.BundleAPI
+{
+    /// <summary>
+    /// A loaded asset bundle.
+    /// </summary>
+    public class LoadedAssetBundle
+    {
+        private Dictionary<string, UnityEngine.Object> _loadedAssets;
+
+        internal LoadedAssetBundle(Dictionary<string, UnityEngine.Object> loadedAssets)
+        {
+            _loadedAssets = loadedAssets;
+        }
+
+        /// <summary>
+        /// Gets an asset from the bundle.
+        /// </summary>
+        /// <typeparam name="TAsset">The type of the asset. Usually <see cref="UnityEngine.GameObject"/>.</typeparam>
+        /// <param name="path">The path to the asset in the bundle.</param>
+        /// <returns>The asset.</returns>
+        public TAsset GetAsset<TAsset>(string path) where TAsset : UnityEngine.Object
+        {
+            string lowerPath = path.ToLower();
+
+            if (_loadedAssets.TryGetValue(lowerPath, out UnityEngine.Object obj))
+            {
+                return obj as TAsset;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Tries to get an asset from the bundle.
+        /// </summary>
+        /// <typeparam name="TAsset">The type of the asset. Usually <see cref="UnityEngine.GameObject"/>.</typeparam>
+        /// <param name="path">The path to the asset in the bundle.</param>
+        /// <param name="asset">Outputs the asset.</param>
+        /// <returns><see langword="true"/> if the asset is found. <see langword="false"/> if the asset isn't found, or couldn't be casted to TAsset</returns>
+        public bool TryGetAsset<TAsset>(string path, out TAsset asset) where TAsset : UnityEngine.Object
+        {
+            string lowerPath = path.ToLower();
+
+            asset = null;
+
+            if (_loadedAssets.TryGetValue(lowerPath, out UnityEngine.Object obj))
+            {
+                if (obj is TAsset tasset) asset = tasset;
+            }
+
+            return asset != null;
+        }
+    }
+}

--- a/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
+++ b/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx;
 using GameNetcodeStuff;
 using HarmonyLib;
+using LC_API.BundleAPI;
 using LC_API.GameInterfaceAPI.Features;
 using System;
 using System.Collections.Generic;
@@ -16,15 +17,15 @@ namespace LC_API.GameInterfaceAPI.Events.Patches.Internal
     [HarmonyPatch(typeof(GameNetworkManager), nameof(GameNetworkManager.Start) )]
     class GameNetworkManagerStartPatch
     {
-        private const string PLAYER_NETWORKING_BUNDLE_LOCATION = "assets/lc_api/playernetworkingprefab.prefab";
+        private const string NETWORKING_BUNDLE_LOCATION = "assets/lc_api/networkingprefab.prefab";
 
-        private static readonly string BUNDLE_PATH = Path.Combine(Paths.PluginPath, "2018-LC_API", "Bundles", "playernetworking");
+        private static readonly string BUNDLE_PATH = Path.Combine(Paths.PluginPath, "2018-LC_API", "Bundles", "networking");
 
         private static void Postfix(GameNetworkManager __instance)
         {
-            Dictionary<string, UnityEngine.Object> assets = BundleAPI.BundleLoader.LoadAssetBundle(BUNDLE_PATH);
+            LoadedAssetBundle assets = BundleLoader.LoadAssetBundle(BUNDLE_PATH);
 
-            GameObject obj = assets[PLAYER_NETWORKING_BUNDLE_LOCATION] as GameObject;
+            GameObject obj = assets.GetAsset<GameObject>(NETWORKING_BUNDLE_LOCATION);
             obj.AddComponent<Features.Player>();
             __instance.GetComponent<NetworkManager>().AddNetworkPrefab(obj);
 

--- a/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
+++ b/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
@@ -1,8 +1,10 @@
-﻿using GameNetcodeStuff;
+﻿using BepInEx;
+using GameNetcodeStuff;
 using HarmonyLib;
 using LC_API.GameInterfaceAPI.Features;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,9 +18,13 @@ namespace LC_API.GameInterfaceAPI.Events.Patches.Internal
     {
         private const string PLAYER_NETWORKING_BUNDLE_LOCATION = "assets/lc_api/playernetworkingprefab.prefab";
 
+        private static readonly string BUNDLE_PATH = Path.Combine(Paths.PluginPath, "2018-LC_API", "Bundles", "playernetworking");
+
         private static void Postfix(GameNetworkManager __instance)
         {
-            GameObject obj = BundleAPI.BundleLoader.GetLoadedAsset<GameObject>(PLAYER_NETWORKING_BUNDLE_LOCATION);
+            Dictionary<string, UnityEngine.Object> assets = BundleAPI.BundleLoader.LoadAssetBundle(BUNDLE_PATH);
+
+            GameObject obj = assets[PLAYER_NETWORKING_BUNDLE_LOCATION] as GameObject;
             obj.AddComponent<Features.Player>();
             __instance.GetComponent<NetworkManager>().AddNetworkPrefab(obj);
 

--- a/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
+++ b/GameInterfaceAPI/Events/Patches/Internal/GameNetworkManagerStartPatch.cs
@@ -14,18 +14,18 @@ using UnityEngine;
 
 namespace LC_API.GameInterfaceAPI.Events.Patches.Internal
 {
-    [HarmonyPatch(typeof(GameNetworkManager), nameof(GameNetworkManager.Start) )]
+    [HarmonyPatch(typeof(GameNetworkManager), nameof(GameNetworkManager.Start))]
     class GameNetworkManagerStartPatch
     {
-        private const string NETWORKING_BUNDLE_LOCATION = "assets/lc_api/networkingprefab.prefab";
-
         private static readonly string BUNDLE_PATH = Path.Combine(Paths.PluginPath, "2018-LC_API", "Bundles", "networking");
+
+        private const string PLAYER_NETWORKING_ASSET_LOCATION = "assets/lc_api/playernetworkingprefab.prefab";
 
         private static void Postfix(GameNetworkManager __instance)
         {
             LoadedAssetBundle assets = BundleLoader.LoadAssetBundle(BUNDLE_PATH);
 
-            GameObject obj = assets.GetAsset<GameObject>(NETWORKING_BUNDLE_LOCATION);
+            GameObject obj = assets.GetAsset<GameObject>(PLAYER_NETWORKING_ASSET_LOCATION);
             obj.AddComponent<Features.Player>();
             __instance.GetComponent<NetworkManager>().AddNetworkPrefab(obj);
 

--- a/LC-API.csproj
+++ b/LC-API.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>LC_API</AssemblyName>
     <Description>Utilities for plugin devs</Description>
+    <Version>3.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>
@@ -14,6 +15,12 @@
     <RootNamespace>LC_API</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Thunderstore\**" />
+    <EmbeddedResource Remove="Thunderstore\**" />
+    <None Remove="Thunderstore\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
@@ -56,4 +63,3 @@
     <Exec Command="cd D:\NetcodePatcher&#xD;&#xA;NetcodePatcher.dll $(TargetDir) deps/" />
   </Target>
 </Project>
-    <Version>3.0.0</Version>

--- a/LC-API.csproj
+++ b/LC-API.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>LC_API</AssemblyName>
     <Description>Utilities for plugin devs</Description>
-    <Version>2.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>
@@ -57,3 +56,4 @@
     <Exec Command="cd D:\NetcodePatcher&#xD;&#xA;NetcodePatcher.dll $(TargetDir) deps/" />
   </Target>
 </Project>
+    <Version>3.0.0</Version>


### PR DESCRIPTION
This will be a breaking change that removes automatic bundle loading unless legacy asset loading is enabled. I will be merging this in a few days so anyone who sees this is aware of the upcoming changes.

The return type of the new `LoadAssetBundle(string filePath)` is not final. I may make a wrapper for casting purposes, we will see. But there will be sufficient time to see changes.